### PR TITLE
Fix README heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚀 Hệ Thống Shopify MCP Workflow (Đã Rebuil## 🏗️ Kiến Trúc Mới)
+# 🚀 Hệ Thống Shopify MCP Workflow (Đã Rebuilt) – 🏗️ Kiến Trúc Mới
 
 **Pipeline Xử Lý Tự Động Hoàn Chỉnh** - Hệ thống xử lý batch **rebuild hoàn toàn** với kiến trúc mới, mã nguồn sạch và hiệu suất tối ưu.
 


### PR DESCRIPTION
## Summary
- fix typo in README heading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a42233ef24832789797a1bb6bc642b